### PR TITLE
Refactor: Disable cancel button during loading in TransferStatusScreen

### DIFF
--- a/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/transfer_status/TransferStatusScreen.kt
+++ b/verifierApp/src/commonMain/kotlin/eu/europa/ec/euidi/verifier/presentation/ui/transfer_status/TransferStatusScreen.kt
@@ -108,7 +108,8 @@ fun TransferStatusScreen(
                     .padding(stickyBottomPaddings),
                 onClick = {
                     viewModel.setEvent(TransferStatusViewModelContract.Event.OnCancelClick)
-                }
+                },
+                enabled = !state.isLoading
             )
         }
     ) { paddingValues ->
@@ -168,6 +169,7 @@ private fun handleNavigationEffect(
 private fun StickyBottomSection(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
+    enabled: Boolean,
 ) {
     Row(
         modifier = modifier
@@ -178,6 +180,7 @@ private fun StickyBottomSection(
                 type = StickyBottomType.OneButton(
                     config = ButtonConfig(
                         type = ButtonType.SECONDARY,
+                        enabled = enabled,
                         onClick = onClick,
                         content = {
                             Text(


### PR DESCRIPTION
This commit updates the `TransferStatusScreen` to disable the "Cancel" button while data is loading.

The `StickyBottomSection` composable now accepts an `enabled` parameter, which is used to control the enabled state of the cancel button. This `enabled` state is derived from the `isLoading` property of the `TransferStatusViewModelContract.State`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable